### PR TITLE
fix: grant Claude issue write permission in GitHub Actions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      issues: read
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--allowed-tools Bash(gh issue:*)'
 


### PR DESCRIPTION
## Summary

- Changed `issues: read` → `issues: write` so the `GITHUB_TOKEN` can create and manage issues
- Enabled `Bash(gh issue:*)` in `claude_args` so Claude is allowed to run `gh issue` commands

## Test plan

- [ ] Tag `@claude` in a PR comment and ask it to create a GitHub issue — it should succeed without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)