### PR TITLE
fix: migrate corrected RoleCatalog to FMStatsApp.Api

### DIFF
--- a/FMStatsApp.Api/Models/RoleCatalog.cs
+++ b/FMStatsApp.Api/Models/RoleCatalog.cs
@@ -33,12 +33,10 @@ namespace FMStatsApp.Models
 					{ "Concentration", 3 },
 					{ "Decisions", 1 },
 					{ "Handling", 3 },
-					{ "JumpingReach", 0 },
 					{ "Kicking", 3 },
-					{ "Passing", 3 },
-					{ "Positioning", 5 },
+					{ "Positioning", 3 },
 					{ "Reflexes", 5 },
-								{ "Throwing", 1 }
+					{ "Throwing", 1 }
 				}),
 
 			new RoleDefinition(
@@ -192,24 +190,24 @@ namespace FMStatsApp.Models
 				Positions: new List<Position> { Position.DC },
 				AttributeWeights: new Dictionary<string, int>
 				{
-					{ "Acceleration", 3 },
-					{ "AerialAbility", 3 },
-					{ "Anticipation", 3 },
+					{ "Acceleration", 5 },
+					{ "Aggression", 1 },
+					{ "Anticipation", 1 },
 					{ "Bravery", 1 },
-					{ "Concentration", 3 },
+					{ "Concentration", 1 },
 					{ "Composure", 5 },
-					{ "Decisions", 3 },
-					{ "FirstTouch", 3 },
+					{ "Decisions", 1 },
+					{ "FirstTouch", 1 },
 					{ "Heading", 3 },
-					{ "JumpingReach", 3 },
+					{ "JumpingReach", 5 },
 					{ "Marking", 3 },
-					{ "Pace", 3 },
-					{ "Passing", 5 },
+					{ "Pace", 5 },
+					{ "Passing", 3 },
 					{ "Positioning", 3 },
-					{ "Strength", 1 },
+					{ "Strength", 3 },
 					{ "Tackling", 3 },
-					{ "Technique", 3 },
-					{ "Vision", 3 }
+					{ "Technique", 1 },
+					{ "Vision", 1 }
 				}),
 
 			new RoleDefinition(
@@ -231,6 +229,7 @@ namespace FMStatsApp.Models
 					{ "Marking", 3 },
 					{ "Pace", 5 },
 					{ "Passing", 3 },
+					{ "Positioning", 3 },
 					{ "Strength", 1 },
 					{ "Tackling", 3 },
 					{ "Technique", 1 },

--- a/FMStatsApp.Core.Tests/HtmlParserTests.cs
+++ b/FMStatsApp.Core.Tests/HtmlParserTests.cs
@@ -181,12 +181,11 @@ public class HtmlParserTests
         // Adrian Kurd Rønning's GKD score — hand-calculated:
         // GKD weights: OneVsOne=1, AerialAbility=3, Agility=5, Anticipation=1,
         //              CommandOfArea=3, Concentration=3, Decisions=1, Handling=3,
-        //              JumpingReach=0, Kicking=3, Passing=3, Positioning=5,
-        //              Reflexes=5, Throwing=1  → weightSum=37
+        //              Kicking=3, Positioning=3, Reflexes=5, Throwing=1  → weightSum=32
         //
-        // 2*1 + 3*3 + 15*5 + 12*1 + 1*3 + 6*3 + 8*1 + 4*3 + 9*0 + 2*3 + 11*3 + 3*5 + 2*5 + 3*1
-        // = 2 + 9 + 75 + 12 + 3 + 18 + 8 + 12 + 0 + 6 + 33 + 15 + 10 + 3 = 206
-        // score = 206 / 37 ≈ 5.567
+        // 2*1 + 3*3 + 15*5 + 12*1 + 1*3 + 6*3 + 8*1 + 4*3 + 2*3 + 3*3 + 2*5 + 3*1
+        // = 2 + 9 + 75 + 12 + 3 + 18 + 8 + 12 + 6 + 9 + 10 + 3 = 167
+        // score = 167 / 32 = 5.21875
         var parser = new HtmlParser(new ScoringCalculator());
         using var stream = File.OpenRead(FixturePath);
 
@@ -194,7 +193,7 @@ public class HtmlParserTests
         var player = players[0];
         var gkd = player.Roles.Single(r => r.ShortRoleName == "GKD");
 
-        float expectedScore = 206f / 37f;
+        float expectedScore = 167f / 32f;
         Assert.True(Math.Abs(gkd.RoleScore - expectedScore) < 0.001f,
             $"GKD expected {expectedScore} but got {gkd.RoleScore}");
     }

--- a/FMStatsApp.Core.Tests/ScoringCalculatorTests.cs
+++ b/FMStatsApp.Core.Tests/ScoringCalculatorTests.cs
@@ -105,13 +105,12 @@ public class ScoringCalculatorTests
         // Hand-calculated for GKD role:
         // Weights: OneVsOne=1, AerialAbility=3, Agility=5, Anticipation=1,
         //          CommandOfArea=3, Concentration=3, Decisions=1, Handling=3,
-        //          JumpingReach=0, Kicking=3, Passing=3, Positioning=5,
-        //          Reflexes=5, Throwing=1  => weightSum=37
+        //          Kicking=3, Positioning=3, Reflexes=5, Throwing=1  => weightSum=32
         //
-        // Base: all attributes = 10 => baseScore = 370
-        // Agility=15 (+5 * 5 = +25), Reflexes=14 (+4 * 5 = +20), Positioning=12 (+2 * 5 = +10)
-        // totalScore = 370 + 25 + 20 + 10 = 425
-        // expectedScore = 425 / 37 ≈ 11.4865
+        // Base: all attributes = 10 => baseScore = 320
+        // Agility=15 (+5 * 5 = +25), Reflexes=14 (+4 * 5 = +20), Positioning=12 (+2 * 3 = +6)
+        // totalScore = 320 + 25 + 20 + 6 = 371
+        // expectedScore = 371 / 32 = 11.59375
         var calculator = new ScoringCalculator();
         var player = CreatePlayerWithAllAttributes(10);
         player.Agility = 15;
@@ -121,7 +120,7 @@ public class ScoringCalculatorTests
         var roles = calculator.AddRoleScoring(player);
         var gkd = roles.Single(r => r.ShortRoleName == "GKD");
 
-        float expectedScore = 425f / 37f;
+        float expectedScore = 371f / 32f;
         Assert.True(
             Math.Abs(gkd.RoleScore - expectedScore) < 0.001f,
             $"GKD expected {expectedScore} but got {gkd.RoleScore}");


### PR DESCRIPTION
## Summary
- Replaced `FMStatsApp.Api/Models/RoleCatalog.cs` with the bug-fixed version from `FMStatsApp`
- GKD role had incorrect weights in the API (`JumpingReach=0`, `Passing=3`, `Positioning=5`) — corrected to match the fixed version (`Positioning=3`, no `JumpingReach`/`Passing`)
- Two DC roles also had structural and value differences — now corrected
- Updated GKD expected values in `ScoringCalculatorTests` and `HtmlParserTests` to match the new weightSum (37→32)

## Test plan
- [ ] All 31 tests pass (`dotnet test FMStatsApp.Core.Tests/`)
- [ ] GKD scoring test reflects correct hand-calculated values
- [ ] No regressions in other role scoring tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)